### PR TITLE
Fix pipeline variable for Add-UserToBC

### DIFF
--- a/Yml/Add-UserToBC.yml
+++ b/Yml/Add-UserToBC.yml
@@ -1,8 +1,12 @@
 name: AddUserToBC_$(AgentPoolName)
 trigger: none
 
+variables:
+- name: AgentPoolName
+  value: $(EnvShortName)
+
 pool:
- name: $(AgentPoolName)
+  name: $(AgentPoolName)
 
 stages:
 - stage: AddUserToBC


### PR DESCRIPTION
## Summary
- update Add-UserToBC.yml so AgentPoolName defaults to EnvShortName

## Testing
- `pwsh -NoLogo -Command "Get-ExecutionPolicy"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489dc7d7088330ba25a2910a71116d